### PR TITLE
Support sha256 hash of header+payload

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -20,14 +20,19 @@ type SigningMethodEd25519 struct {
 // SigningMethodEd25519i is a specific instance for Ed25519.
 var SigningMethodEd25519i *SigningMethodEd25519
 
-// SigningMethodEd25519Sha is a specific instance for Ed25519 with hashing enabled
-var SigningMethodEd25519Sha *SigningMethodEd25519
+// SigningMethodEd25519Sha is a non-standard, specific instance for Ed25519
+// with sha256 hashing enabled.
+var SigningMethodEd25519Sha256 *SigningMethodEd25519
 
 func init() {
 	SigningMethodEd25519i = &SigningMethodEd25519{"EdDSA", false}
-	SigningMethodEd25519Sha = &SigningMethodEd25519{"EdDSA", true}
 	jwt.RegisterSigningMethod(SigningMethodEd25519i.Alg(), func() jwt.SigningMethod {
 		return SigningMethodEd25519i
+	})
+	// Register non-standard method
+	SigningMethodEd25519Sha256 = &SigningMethodEd25519{"EdDSASha256", true}
+	jwt.RegisterSigningMethod(SigningMethodEd25519Sha256.Alg(), func() jwt.SigningMethod {
+		return SigningMethodEd25519Sha256
 	})
 }
 

--- a/jwt.go
+++ b/jwt.go
@@ -1,21 +1,31 @@
 package eddsa
 
 import (
+	"crypto/sha256"
+
 	"github.com/dgrijalva/jwt-go"
 	"github.com/libp2p/go-libp2p-core/crypto"
 )
 
 // SigningMethodEd25519 implements the Ed25519 signing method.
-// Expects *crypto.Ed25519PublicKey for signing and *crypto.Ed25519PublicKey for validation.
+// Expects *crypto.Ed25519PublicKey for signing and *crypto.Ed25519PublicKey
+// for validation.
+// The signing method can be optionally configured to sign and validate the
+// sha256 hash of the input string.
 type SigningMethodEd25519 struct {
 	Name string
+	Hash bool
 }
 
 // SigningMethodEd25519i is a specific instance for Ed25519.
 var SigningMethodEd25519i *SigningMethodEd25519
 
+// SigningMethodEd25519Sha is a specific instance for Ed25519 with hashing enabled
+var SigningMethodEd25519Sha *SigningMethodEd25519
+
 func init() {
-	SigningMethodEd25519i = &SigningMethodEd25519{"EdDSA"}
+	SigningMethodEd25519i = &SigningMethodEd25519{"EdDSA", false}
+	SigningMethodEd25519Sha = &SigningMethodEd25519{"EdDSA", true}
 	jwt.RegisterSigningMethod(SigningMethodEd25519i.Alg(), func() jwt.SigningMethod {
 		return SigningMethodEd25519i
 	})
@@ -44,6 +54,15 @@ func (m *SigningMethodEd25519) Verify(signingString, signature string, key inter
 		return jwt.ErrInvalidKeyType
 	}
 
+	if m.Hash {
+		h := sha256.New()
+		_, err := h.Write([]byte(signingString))
+		if err != nil {
+			return err
+		}
+		signingString = string(h.Sum(nil))
+	}
+
 	// verify the signature
 	valid, err := ed25519Key.Verify([]byte(signingString), sig)
 	if err != nil {
@@ -65,6 +84,15 @@ func (m *SigningMethodEd25519) Sign(signingString string, key interface{}) (stri
 	// validate type of key
 	if ed25519Key, ok = key.(*crypto.Ed25519PrivateKey); !ok {
 		return "", jwt.ErrInvalidKey
+	}
+
+	if m.Hash {
+		h := sha256.New()
+		_, err := h.Write([]byte(signingString))
+		if err != nil {
+			return "", err
+		}
+		signingString = string(h.Sum(nil))
 	}
 
 	sigBytes, err := ed25519Key.Sign([]byte(signingString))

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -18,6 +18,7 @@ var ed25519TestData = []struct {
 	alg         string
 	claims      map[string]interface{}
 	valid       bool
+	hash        bool
 }{
 	{
 		"EdDSA",
@@ -25,6 +26,7 @@ var ed25519TestData = []struct {
 		"EdDSA",
 		map[string]interface{}{"jti": "foo", "sub": "bar"},
 		true,
+		false,
 	},
 	{
 		"invalid key",
@@ -32,6 +34,15 @@ var ed25519TestData = []struct {
 		"EdDSA",
 		map[string]interface{}{"jti": "foo", "sub": "bar"},
 		false,
+		false,
+	},
+	{
+		"sha256 hash for signature",
+		"eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJmb28iLCJzdWIiOiJiYXIifQ.x1tRfmjfL70P7jxXHTfW47D9sjwbl0BGJECjIfocntlQi-ACVF8OuaW829f-5ag6HBt_E76Eh8IkLXeBK-gsBA",
+		"EdDSA",
+		map[string]interface{}{"jti": "foo", "sub": "bar"},
+		true,
+		true,
 	},
 }
 
@@ -49,7 +60,12 @@ func TestSigningMethodEd25519_Sign(t *testing.T) {
 	for _, data := range ed25519TestData {
 		if data.valid {
 			parts := strings.Split(data.tokenString, ".")
-			method := jwt.GetSigningMethod(data.alg)
+			var method jwt.SigningMethod
+			if data.hash {
+				method = eddsa.SigningMethodEd25519Sha
+			} else {
+				method = jwt.GetSigningMethod(data.alg)
+			}
 			sig, err := method.Sign(strings.Join(parts[0:2], "."), sk)
 			if err != nil {
 				t.Errorf("[%v] error signing token: %v", data.name, err)
@@ -69,7 +85,12 @@ func TestSigningMethodEd25519_Verify(t *testing.T) {
 	for _, data := range ed25519TestData {
 		parts := strings.Split(data.tokenString, ".")
 
-		method := jwt.GetSigningMethod(data.alg)
+		var method jwt.SigningMethod
+		if data.hash {
+			method = eddsa.SigningMethodEd25519Sha
+		} else {
+			method = jwt.GetSigningMethod(data.alg)
+		}
 		err := method.Verify(strings.Join(parts[0:2], "."), parts[2], pk)
 		if data.valid && err != nil {
 			t.Errorf("[%v] error while verifying key: %v", data.name, err)
@@ -90,6 +111,11 @@ func TestGenerateEd25519Token(t *testing.T) {
 		Subject: "bar",
 	}
 	_, err = jwt.NewWithClaims(eddsa.SigningMethodEd25519i, claims).SignedString(sk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = jwt.NewWithClaims(eddsa.SigningMethodEd25519Sha, claims).SignedString(sk)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -39,7 +39,7 @@ var ed25519TestData = []struct {
 	{
 		"sha256 hash for signature",
 		"eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJqdGkiOiJmb28iLCJzdWIiOiJiYXIifQ.x1tRfmjfL70P7jxXHTfW47D9sjwbl0BGJECjIfocntlQi-ACVF8OuaW829f-5ag6HBt_E76Eh8IkLXeBK-gsBA",
-		"EdDSA",
+		"EdDSASha256",
 		map[string]interface{}{"jti": "foo", "sub": "bar"},
 		true,
 		true,
@@ -60,12 +60,8 @@ func TestSigningMethodEd25519_Sign(t *testing.T) {
 	for _, data := range ed25519TestData {
 		if data.valid {
 			parts := strings.Split(data.tokenString, ".")
-			var method jwt.SigningMethod
-			if data.hash {
-				method = eddsa.SigningMethodEd25519Sha
-			} else {
-				method = jwt.GetSigningMethod(data.alg)
-			}
+
+			method := jwt.GetSigningMethod(data.alg)
 			sig, err := method.Sign(strings.Join(parts[0:2], "."), sk)
 			if err != nil {
 				t.Errorf("[%v] error signing token: %v", data.name, err)
@@ -85,12 +81,7 @@ func TestSigningMethodEd25519_Verify(t *testing.T) {
 	for _, data := range ed25519TestData {
 		parts := strings.Split(data.tokenString, ".")
 
-		var method jwt.SigningMethod
-		if data.hash {
-			method = eddsa.SigningMethodEd25519Sha
-		} else {
-			method = jwt.GetSigningMethod(data.alg)
-		}
+		method := jwt.GetSigningMethod(data.alg)
 		err := method.Verify(strings.Join(parts[0:2], "."), parts[2], pk)
 		if data.valid && err != nil {
 			t.Errorf("[%v] error while verifying key: %v", data.name, err)
@@ -115,7 +106,7 @@ func TestGenerateEd25519Token(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = jwt.NewWithClaims(eddsa.SigningMethodEd25519Sha, claims).SignedString(sk)
+	_, err = jwt.NewWithClaims(eddsa.SigningMethodEd25519Sha256, claims).SignedString(sk)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This is a minimal PR that adds support for sha256 hashed signatures. Essentially, some external tools automatically apply sha256 hashing to the input string when signing. This means that the signature of the header.payload will not match. This minimal PR provides support for sha256 hashing, while keeping the default behavior unchanged.

There are two things off the top of my head that we might want to reconsider:
1. Since sha256 hashing of the payload prior to signing and validation is non-standard, expecting the EdDSA method name shouldn't apply in this case really. So I've opted to use a different method name for when sha256 hashing is to be applied? Is this a bad/good idea? Since other validators won't know what to do in that case, it seems best to just use some other non-standard alg name
2. Perhaps we should keep this even simpler, and just _try_ to validate without the hash, and fallback to validating the sha256 hash upon failure, and then fail entirely if even that doesn't work? We then wouldn't support _signing_ with the sha256 hash, because this is non-standard anyway.